### PR TITLE
use the existing emacs server process in daemonize mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,76 +1,57 @@
 'use strict';
-var renderer = require('./lib/renderer');
-var assign = require('object-assign');
-var read_info = require('./lib/read-info');
-var emacs = require('./lib/emacs');
+let renderer = require('./lib/renderer');
+let assign = require('object-assign');
+let read_info = require('./lib/read-info');
+let emacs = require('./lib/emacs');
 
-var fs = require('fs');
-var path = require('path');
-
-// for detect if we use `hexo s'
-var server_mode = false;
-var emacs_server_start = false;
+let fs = require('fs');
+let path = require('path');
 
 // Init option
 hexo.config.org = assign({
   emacs: 'emacs',
   emacsclient: 'emacsclient',   // user should not setup this if renderer work correctly
   common: '#+OPTIONS: toc:nil num:nil\n#+BIND: org-html-postamble nil',
-  export_cfg: "(progn (package-initialize)(require 'org) (require 'org-clock) (require 'ox))", // FIXME: why not remove this ?
   cachedir: './hexo-org-cache/',
   clean_cache: false,            // enable this to make 'hexo clean' also clean the cache
   theme: '',
   user_config: '',
   htmlize: false,
   line_number: false,
-  daemonize: true,              // set false to disable use emacs server
-  debug: false
+  daemonize: true,              // set true to use existing server
+  debug: false,
+  server_file: "~/.emacs.d/server/server"
 }, hexo.config.org);
 
 hexo.on('ready', function() {
-  // detect if current is execute for server, we have different method to handle emacs server exit.
-  // some people may use 'hexo generate --watch' or 'hexo generate -w', which we also need to keep emacs server exist
-  server_mode = process.argv.indexOf('server') > 0 || process.argv.indexOf('s') > 0 || process.argv.indexOf('--watch') > 0 || process.argv.indexOf('-w') > 0;
 
   // detect if we are going to clear all cache file (the 'cachedir/emacs.d' will not remove )
   if(process.argv.indexOf('clean') > 0 ) {
-    var dir = hexo.config.org.cachedir;
+    let dir = hexo.config.org.cachedir;
     if (fs.existsSync(dir) && hexo.config.org.clean_cache) {
-      var files = fs.readdirSync(dir);
+      let files = fs.readdirSync(dir);
       files.forEach(function (filename) {
-        var fullname = path.join(dir, filename);
-        var stats = fs.statSync(fullname);
+        let fullname = path.join(dir, filename);
+        let stats = fs.statSync(fullname);
         if (!stats.isDirectory())
           fs.unlink(fullname);
       });
     }
   }
 
-  // start emacs server only on:
-  //   hexo s
-  //   hexo server
-  //   hexo render
-  //   hexo generator
-  //   hexo g
-  if (server_mode || process.argv.indexOf('render') > 0 || process.argv.indexOf('generate') > 0 || process.argv.indexOf('g') > 0) {
-    // start emacs server
-    emacs.server.start(hexo);
-    emacs_server_start = true;
-  }
-
+  emacs.server
+    .check(hexo)
+    .then(emacs.server.load_config)
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
 });
 
 // When time to exit hexo, kill emacs process
-hexo.on('exit', function(err) {
-  // If use `hexo server`, the hexo will first enter `.on(exit)` event then start the server.
-  // that's why we skip emacs.server.stop() when first etner here with server mode.
-  if (server_mode) {
-    server_mode = false;
-    return;
-  }
-  if (emacs_server_start)
-    emacs.server.stop(hexo);
+hexo.on('exit', err => {
+  if(err) console.error(err);
 });
 
-hexo.extend.renderer.register('org', 'html', renderer.bind(hexo), false);
 hexo.extend.filter.register('before_post_render', read_info);
+hexo.extend.renderer.register('org', 'html', renderer.bind(hexo), false);

--- a/lib/emacs.js
+++ b/lib/emacs.js
@@ -1,249 +1,151 @@
 'use strict';
 
-var child_process = require('child_process');
-var slash = require('slash');
-var fs = require('fs-extra');
-var tmp = require('tmp');
-var path = require('path');
-var retry = require('retry');
+let child_process = require('child_process');
+let slash = require('slash');
+let fs = require('fs-extra');
+let tmp = require('tmp');
+let path = require('path');
+let retry = require('retry');
 
 // A variable to save current config.org.emacsclient info
-var emacsclient = "emacsclient";
+let emacsclient = "emacsclient";
 
-// A variable to save current emacs server status
-var emacs_server_is_dead = false;
+const EMACS_SERVER_OFF = 0;
+const EMACS_SERVER_NOT_LOAD_HEXO = 1;
+const EMACS_SERVER_ON = 2;
 
-// Set false to disable emacs server
-var use_emacs_server = true;
-
-// NOTE: Maybe make this variable configurable ?
-// emacs daemon server-name
-var server_name = "hexo-renderer-org";
-
-// NOTE: Maybe make this variable configurable ?
-// Directory to place server socket file
-var server_dir = "./emacs.d/server";
+let emacs_server_status = EMACS_SERVER_OFF;
 
 // Emacs daemon server-file (full path)
-var server_file = undefined;
+let server_file = "~/.emacs.d/server/server";
 
-function fix_filepath(s)
-{
-    // unix way of filepath
-    s = slash(s);
-    // convert " -> \"
-    s = s.replace(/[\""]/g, '\\"');
-    return s;
+function fix_filepath(s) {
+  if (s.length <= 0) return s;
+
+  if (s[0] === '~') {
+    s = path.join(process.env.HOME, s.slice(1));
+  }
+
+  // unix way of filepath
+  s = slash(s);
+  // convert " -> \"
+  s = s.replace(/[\""]/g, '\\"');
+  return s;
 }
 
-function fix_elisp(s)
-{
-    // remove lisp's comments
-    s = s.replace(/^[\s\t]*;.*$/gm, "");
+function fix_elisp(s) {
+  // remove lisp's comments
+  s = s.replace(/^[\s\t]*;.*$/gm, "");
 
-    // remove trailing garbage to prevent emacs eval fail
-    s = s.replace(/\r?\n|\r/g, "");
+  // remove trailing garbage to prevent emacs eval fail
+  s = s.replace(/\r?\n|\r/g, "");
 
-    return s;
+  return s;
 }
 
 // convert true, false => t, nil
-function elisp_bool(b)
-{
-    return (b == true) ? "t" : "nil";
+function elisp_bool(b) {
+  return (b == true) ? "t" : "nil";
 }
 
-function update_server_file(hexo) {
-    var config = hexo.config;
-    var cachedir = config.org.cachedir;
-    server_file = path.join(process.cwd(), cachedir, server_dir, server_name);
-    server_file = fix_filepath(server_file);
-    if (config.org.debug)
-        console.log("Update server_file =", server_file);
-    return server_file;
+function format_hexo_configs(hexo_config, user_config) {
+  // Find emacs entry point hexo-renderer-org.el
+  let init_el = path.join(process.cwd(), "emacs", "hexo-renderer-org.el");
+  if (!fs.existsSync(init_el))
+    init_el = fix_filepath(path.join(process.cwd(), "node_modules", "hexo-renderer-org", "emacs", "hexo-renderer-org.el"));
+
+  let debug_file = tmp.fileSync();
+  let emacs_lisp = `
+  (progn
+    ;; Setup user's config
+    (setq hexo-renderer-org-cachedir     "${fix_filepath(hexo_config.org.cachedir) || ""}")
+    (setq hexo-renderer-org-user-config  "${fix_filepath(user_config) || ""}")
+    (setq hexo-renderer-org-theme        "${hexo_config.org.theme || ""}")
+    (setq hexo-renderer-org-common-block "${hexo_config.org.common.replace(/\n/g, "\\n")}")
+    (setq hexo-renderer-org--debug-file  "${fix_filepath(debug_file.name)}")
+    (setq hexo-renderer-org--use-htmlize  ${elisp_bool((hexo_config.org.htmlize))})
+    (setq org-hexo-use-htmlize            ${elisp_bool((hexo_config.org.htmlize))})
+    (setq org-hexo-use-line-number        ${elisp_bool(hexo_config.org.line_number)})
+    ;; load init.el
+    (load "${init_el}"))
+  `;
+
+  return emacs_lisp;
 }
 
-function get_server_file(hexo) {
-    return server_file || update_server_file(hexo);
+function get_emacs_server_socket_file(hexo) {
+  return fix_filepath(hexo.config.org.server_file || server_file);
 }
 
-function ensure_server_dir(hexo) {
-    // NOTE: Ensure server-dir exist
-    // It seems that emacs doesn't prepare the directory for the server-file,
-    // and if the dir doesn't exist, emacs cannot create the server file properly,
-    // though the server daemon is running, but emacsclient could never get the
-    // connection done, because the inaccessibility to the server-file, this
-    // behavior is confirmed on Windows MSYS2 MinGW64 Shell, with GNU Emacs 25.2.1,
-    // installed using command pacman -S mingw-w64-x86_64-emacs.
-    var dir = path.dirname(get_server_file(hexo));
-    fs.mkdirsSync(dir);
-    return fs.existsSync(dir);
+function emacs_server_check(hexo) {
+  // it has been checked
+  if (emacs_server_status !== EMACS_SERVER_OFF)
+    return Promise.resolve(hexo);
+
+  let socket_file = get_emacs_server_socket_file(hexo);
+  return new Promise((resolve, reject) => {
+    fs.stat(socket_file, (err, stats) => {
+      // file does not exist
+      if (err) return reject(err);
+      // file type is not socket
+      if (!stats.isSocket()) return reject(`File Type Error: type of ${server_file} is not socket.`);
+
+      // socket file exist, change emacs_server_status
+      emacs_server_status = EMACS_SERVER_NOT_LOAD_HEXO;
+      resolve(hexo)
+    })
+  })
 }
 
-// pass hexo.config to this function
-function emacs_server_start(hexo)
-{
-    var config = hexo.config;
-    config.highlight = config.highlight || {};
+function emacs_server_load_config(hexo) {
+  // it has been loaded
+  if (emacs_server_status !== EMACS_SERVER_NOT_LOAD_HEXO)
+    return Promise.resolve(hexo);
 
-    if (!config.org.daemonize) {
-        use_emacs_server = false;
-        return;
-    }
+  let config = hexo.config;
+  let emacs_lisp = format_hexo_configs(config, "");
 
-    // save config.org.emacsclient info
-    emacsclient = config.org.emacsclient;
+  if (config.org.debug) {
+    console.log("\n--------------load hexo config----------------");
+    console.log("emacs: ", config.org.emacsclient);
+    console.log("emacs_lisp: \n", emacs_lisp);
+    console.log("\n--------------load hexo config----------------");
+  }
 
-    // Find emacs entry point hexo-renderer-org.el
-    var init_el = path.join(process.cwd(), "emacs", "hexo-renderer-org.el" );
-    if (!fs.existsSync(init_el))
-        init_el = path.join(process.cwd(), "node_modules", "hexo-renderer-org", "emacs", "hexo-renderer-org.el" );
+  // Remove triling garbages
+  emacs_lisp = fix_elisp(emacs_lisp);
 
-    init_el = fix_filepath(init_el);
+  let socket_file = get_emacs_server_socket_file(hexo);
+  let exec_args = ['-s', socket_file, '-e', emacs_lisp];
 
-    var debug_file = tmp.fileSync();
-
-    // convert user_config to absolute path
-    var user_config = "";
-    if (config.org.user_config)
-        user_config = path.join(process.cwd(), path.normalize(config.org.user_config));
-
-    // Ensure server-dir exist
-    if (!ensure_server_dir(hexo)) {
-        if (config.org.debug)
-            console.log("Warning, directory to emacs server-file doesn't exist.");
-        // FIXME: Maybe add some code here to avoid inaccessible emacs daemon.
-    }
-
-    var emacs_lisp = `
-(progn
-  ;; Setup user's config
-  (setq hexo-renderer-org-cachedir     "${fix_filepath(config.org.cachedir) || ""}")
-  (setq hexo-renderer-org-user-config  "${fix_filepath(user_config) || ""}")
-  (setq hexo-renderer-org-theme        "${config.org.theme || ""}")
-  (setq hexo-renderer-org-common-block "${config.org.common.replace(/\n/g, "\\n")}")
-  (setq hexo-renderer-org--debug-file  "${fix_filepath(debug_file.name)}")
-  (setq hexo-renderer-org--use-htmlize  ${elisp_bool((config.org.htmlize))})
-  (setq org-hexo-use-htmlize            ${elisp_bool((config.org.htmlize))})
-  (setq org-hexo-use-line-number        ${elisp_bool(config.org.line_number)})
-  ;; load init.el
-  (load "${init_el}"))
-`;
-
-    if (config.org.debug) {
-        console.log("\n------------------------------");
-        console.log("emacs: ", config.org.emacs);
-        console.log("emacs_lisp: \n", emacs_lisp);
-        console.log("\n------------------------------");
-    }
-
-    // Remove triling garbages
-    emacs_lisp = fix_elisp(emacs_lisp);
-
-    var exec_args = ['-Q','--daemon=' + get_server_file(hexo), '--eval', emacs_lisp];
-
-    var proc = child_process.spawn(config.org.emacs, exec_args, {
-        stdio: 'inherit'              // emacs's htmlize package need tty
+  return new Promise((resolve, reject) => {
+    // load hexo-renderer-org.el via emacsclient
+    let proc = child_process.spawn(config.org.emacsclient, exec_args, {
+      stdio: 'inherit'
     });
 
-    proc.on('exit', function(code) {
-        try {
-            var oops = JSON.parse(fs.readFileSync(debug_file.name, "utf8"));
-            console.error(oops.message);
-            emacs_server_is_dead = true;
-            hexo.exit(-1);      // FIXME: why this can't really make 'hexo s' stop ?
-        }
-        catch(e) {
-            // forget about it :)
-        }
+    proc.on('exit', (code, signal) => {
+      if (code !== 0) reject(`Emacs Load Config Error: emacsclient exit with ${code}`);
+
+      emacs_server_status = EMACS_SERVER_ON;
+      resolve(hexo);
     });
 
-    return proc;
-}
-
-function emacs_server_stop(hexo)
-{
-    return new Promise((resolve,reject) => {
-        var config = hexo.config;
-
-        if (emacs_server_is_dead)
-            return;
-
-        if (!use_emacs_server)
-            return;
-
-        var proc = child_process.spawn(emacsclient, ['-s', get_server_file(hexo), '-e', '(kill-emacs)'], {
-            // detached: true
-        });
-
-        proc.on('exit', function(code) {
-            if (code != 0) {
-                // FIXME:
-                // What timeout interval is better, or spinning with no timeout ?
-                setTimeout(() => {
-                    if (config.org.debug)
-                        console.log("Wait for emacs daemon exit!!");
-                    resolve(emacs_server_stop(hexo));
-                }, 100);
-                return;
-            }
-            // FIXME:
-            // What if emacsclient doesn't successfully connect to emacs daemon (wrong server file name),
-            // or emacs daemon doesn't successfully initialize, the emacs daemon becomes a zombie process
-            // without actually serving as a server. In these situation the command '(kill-emacs)' will
-            // never reach to emacs daemon, thus causing endless wait.
-            resolve();
-        });
+    proc.on('error', (err) => {
+      reject(`Emacs Load Config Error: ${err}`);
     });
+  })
 }
 
-function emacs_server_wait(hexo)
-{
-    return new Promise((resolve,reject) => {
-        var config = hexo.config;
-        if (emacs_server_is_dead)
-            return;
 
-        if (!use_emacs_server)
-            return;
+function emacs_client(hexo, data) {
+  console.log("emacs client")
+  let config = hexo.config;
 
-        var proc = child_process.spawn(emacsclient, ['-s', get_server_file(hexo), '-e', '(message "ping")'], {
-        });
-
-        proc.on('exit', function(code) {
-            if (code != 0) {
-                // FIXME:
-                // What timeout interval is better, or spinning with no timeout ?
-                setTimeout(() => {
-                    if (config.org.debug)
-                        console.log("Wait for emacs daemon startup!!");
-                    resolve(emacs_server_wait(hexo));
-                }, 100);
-                return;
-            }
-            // FIXME:
-            // What if emacsclient doesn't successfully connect to emacs daemon (wrong server file name),
-            // or emacs daemon doesn't successfully initialize, the emacs daemon becomes a zombie process
-            // without actually serving as a server. In these situation the command '(kill-emacs)' will
-            // never reach to emacs daemon, thus causing endless wait.
-            resolve();
-        });
-    });
-}
-
-function emacs_client(hexo, data, callback)
-{
-    var config = hexo.config;
-    if (emacs_server_is_dead)
-        return;
-
-    config.highlight = config.highlight || {};
-
-    var emacs_path = config.org.emacs;
-
-    var output_file = tmp.fileSync();
-
-    var emacs_lisp = `
+  config.highlight = config.highlight || {};
+  let emacs_path = config.org.emacs;
+  let output_file = tmp.fileSync();
+  let emacs_lisp = `
 (progn
   ;; render file according to args
   (hexo-renderer-org '(:file         "${fix_filepath(data.path)}"
@@ -251,62 +153,62 @@ function emacs_client(hexo, data, callback)
                        )))
 `;
 
-    // Enable this for debugging
-    if (config.org.debug) {
-        console.log("\n------------------------------");
-        console.log("emacsclient: ", config.org.emacsclient);
-        console.log("emacs_lisp: \n", emacs_lisp);
-        console.log("\n------------------------------");
-    }
+  // Enable this for debugging
+  if (config.org.debug) {
+    console.log("\n--------------hexo render----------------");
+    console.log("emacsclient: ", config.org.emacsclient);
+    console.log("emacs_lisp: \n", emacs_lisp);
+    console.log("\n--------------hexo render----------------");
+  }
 
-    // Remove triling garbages
-    emacs_lisp = fix_elisp(emacs_lisp);
+  // Remove triling garbages
+  emacs_lisp = fix_elisp(emacs_lisp);
+  let socket_file = get_emacs_server_socket_file(hexo);
 
-    var exec_args = ['-s', get_server_file(hexo), '-e', emacs_lisp];
+  let exec_args = ['-s', socket_file, '-e', emacs_lisp];
 
-    // if (config.org.export_cfg != '')
-    //    exec_args.splice(1,0,'--execute', config.org.export_cfg);
+  // if (config.org.export_cfg != '')
+  //    exec_args.splice(1,0,'--execute', config.org.export_cfg);
 
-    var operation = retry.operation( {
-        retries: 100,
-        factor: 2,
-        minTimeout: 100,
-        maxTimeout: 1000,
-        randomize: true
-    });
+  let operation = retry.operation({
+    retries: 100,
+    factor: 2,
+    minTimeout: 100,
+    maxTimeout: 1000,
+    randomize: true
+  });
 
-    operation.attempt(function (currentAttempt) {
+  return new Promise((resolve, reject) => {
+    operation.attempt(currentAttempt => {
+      let proc = child_process.spawn(config.org.emacsclient, exec_args, {
+        stdio: 'inherit'
+      });
 
-        var proc = child_process.spawn(config.org.emacsclient, exec_args, {
-            stdio: 'inherit'
-        });
+      let retryOrExit = err => {
+        if (currentAttempt > 100) return reject("Convert Error: emacs client try too many times.")
+        if (config.org.debug)
+          console.log(`RETRY(${currentAttempt}): `, data.path);
 
-        function retryOrExit(err) {
-            if (config.org.debug)
-                console.log("RETRY: ", data.path);
+        const retrying = operation.retry(err);
+        if (!retrying) {
 
-            if (emacs_server_is_dead)
-                callback("");
+          if (config.org.debug)
+            console.log("DONE: ", data.path);
 
-            const retrying = operation.retry(err);
-            if (!retrying) {
-
-                if (config.org.debug)
-                    console.log("DONE: ", data.path);
-
-                var result = fs.readFileSync(output_file.name, 'utf8');
-                callback(result); // return callback
-            }
+          let result = fs.readFileSync(output_file.name, 'utf8');
+          resolve(result); // return callback
         }
+      }
 
-        proc.on('exit', (code, signal) => {
-            retryOrExit(code !== 0);
-        });
+      proc.on('exit', (code, signal) => {
+        retryOrExit(code !== 0);
+      });
 
-        proc.on('error', (err) => {
-            retryOrExit(err);
-        });
+      proc.on('error', (err) => {
+        retryOrExit(err);
+      });
     });
+  })
 }
 
 
@@ -316,29 +218,29 @@ function emacs_client(hexo, data, callback)
 // 3. does not support htmlize syntax higlight
 // 4. maybe more slow
 // 5. just for some system can't use emacs daemon method
-function emacs_process(hexo, data, callback)
-{
-    var config = hexo.config;
-    config.highlight = config.highlight || {};
+function emacs_process(hexo, data) {
+  console.log("emacs process")
+  let config = hexo.config;
+  config.highlight = config.highlight || {};
 
-    var emacs_path = config.org.emacs;
+  let emacs_path = config.org.emacs;
 
-    // Find emacs entry point hexo-renderer-org.el
-    var init_el = path.join(process.cwd(), "emacs", "hexo-renderer-org.el" );
-    if (!fs.existsSync(init_el))
-        init_el = path.join(process.cwd(), "node_modules", "hexo-renderer-org", "emacs", "hexo-renderer-org.el" );
+  // Find emacs entry point hexo-renderer-org.el
+  let init_el = path.join(process.cwd(), "emacs", "hexo-renderer-org.el");
+  if (!fs.existsSync(init_el))
+    init_el = path.join(process.cwd(), "node_modules", "hexo-renderer-org", "emacs", "hexo-renderer-org.el");
 
-    init_el = fix_filepath(init_el);
+  init_el = fix_filepath(init_el);
 
-    var debug_file = tmp.fileSync();
-    var output_file = tmp.fileSync();
+  let debug_file = tmp.fileSync();
+  let output_file = tmp.fileSync();
 
-    // convert user_config to absolute path
-    var user_config = "";
-    if (config.org.user_config)
-        user_config = path.join(process.cwd(), path.normalize(config.org.user_config));
+  // convert user_config to absolute path
+  let user_config = "";
+  if (config.org.user_config)
+    user_config = path.join(process.cwd(), path.normalize(config.org.user_config));
 
-    var emacs_lisp = `
+  let emacs_lisp = `
 (progn
   ;; Setup user's config
   (setq hexo-renderer-org-daemonize nil)
@@ -359,53 +261,53 @@ function emacs_process(hexo, data, callback)
   (kill-emacs))
 `;
 
-    // Enable this for debugging
-    if (config.org.debug) {
-        console.log("\n------------------------------");
-        console.log("emacs: ", config.org.emacs);
-        console.log("type: emacs process");
-        console.log("emacs_lisp: \n", emacs_lisp);
-        console.log("\n------------------------------");
-    }
+  // Enable this for debugging
+  if (config.org.debug) {
+    console.log("\n------------------------------");
+    console.log("emacs: ", config.org.emacs);
+    console.log("type: emacs process");
+    console.log("emacs_lisp: \n", emacs_lisp);
+    console.log("\n------------------------------");
+  }
 
-    // Remove triling garbages
-    emacs_lisp = fix_elisp(emacs_lisp);
+  // Remove triling garbages
+  emacs_lisp = fix_elisp(emacs_lisp);
 
-    var exec_args = ['--batch', '--eval', emacs_lisp];
+  let exec_args = ['--batch', '--eval', emacs_lisp];
 
-    // if (config.org.export_cfg != '')
-    //    exec_args.splice(1,0,'--execute', config.org.export_cfg);
+  // if (config.org.export_cfg != '')
+  //    exec_args.splice(1,0,'--execute', config.org.export_cfg);
 
-    var proc = child_process.spawn(config.org.emacs, exec_args);
+  return new Promise((resolve, reject) => {
+    let proc = child_process.spawn(config.org.emacs, exec_args);
 
     proc.on('exit', (code, signal) => {
-        if (config.org.debug)
-            console.log("DONE: ", data.path);
+      if (config.org.debug)
+        console.log("DONE: ", data.path);
 
-        var result = fs.readFileSync(output_file.name, 'utf8');
-        callback(result); // return callback
+      let result = fs.readFileSync(output_file.name, 'utf8');
+      resolve(result); // return callback
     });
+  })
+
 }
 
 module.exports = {
 
-    server: {
-        start: function(hexo) {
-            return emacs_server_start(hexo);
-        },
-        stop: function(hexo) {
-            return emacs_server_stop(hexo);
-        },
-        wait: function(hexo) {
-            return emacs_server_wait(hexo);
-        }
+  server: {
+    check: function(hexo) {
+      return emacs_server_check(hexo);
     },
-
-    client: function(hexo, data, callback) {
-        return emacs_client(hexo, data, callback);
-    },
-
-    process: function(hexo, data, callback) {
-        return emacs_process(hexo, data, callback);
+    load_config: function(hexo) {
+      return emacs_server_load_config(hexo);
     }
+  },
+
+  client: function(hexo, data, callback) {
+    return emacs_client(hexo, data, callback);
+  },
+
+  process: function(hexo, data, callback) {
+    return emacs_process(hexo, data, callback);
+  }
 };

--- a/lib/read-info.js
+++ b/lib/read-info.js
@@ -1,24 +1,24 @@
 'use strict';
 
-var moment = require('moment');
+let moment = require('moment');
 
 function read_info(data) {
-  var _items = {};
+  let _items = {};
   read_in();
   read_all();
   return data;
 
   function split2(str, delim) {
-    var parts = str.split(delim);
+    let parts = str.split(delim);
     return [parts[0], parts.splice(1, parts.length).join(delim)];
   }
 
   function read_in() {
-    var r = data.content.match(/#\+[a-zA-Z]*:.*\n/g);
+    let r = data.content.match(/#\+[a-zA-Z]*:.*\n/g);
     if (r) {
-      for (var i = 0; i < r.length; i++) {
-        var parts = split2(r[i], ':');
-        var key = parts[0].substring(2).trim();
+      for (let i = 0; i < r.length; i++) {
+        let parts = split2(r[i], ':');
+        let key = parts[0].substring(2).trim();
         if(!_items[key])
           _items[key] = parts[1].trim();
       }
@@ -81,12 +81,12 @@ function read_info(data) {
   function read_alias() {
     // support array, re-read again
     if(_items.ALIAS){
-      var r = data.content.match(/#\+ALIAS:.*\n/g);
+      let r = data.content.match(/#\+ALIAS:.*\n/g);
       if (r) {
         data.alias = [];
-        for (var i = 0; i < r.length; i++) {
-          var parts = split2(r[i], ':');
-          var key = parts[0].substring(2).trim();
+        for (let i = 0; i < r.length; i++) {
+          let parts = split2(r[i], ':');
+          let key = parts[0].substring(2).trim();
           data.alias.push( parts[1].trim());
         }
       }

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,151 +1,148 @@
 'use strict';
 
-var cheerio = require('cheerio');
-var util = require('hexo-util');
-var os = require('os');
-var iconv = require('iconv-lite');
-var jsonfile = require('jsonfile');
-var md5 = require('md5');
-var fs = require('fs-extra');
-var tmp = require('tmp');
-var path = require('path');
-var highlight = util.highlight;
+let cheerio = require('cheerio');
+let util = require('hexo-util');
+let os = require('os');
+let iconv = require('iconv-lite');
+let jsonfile = require('jsonfile');
+let md5 = require('md5');
+let fs = require('fs-extra');
+let tmp = require('tmp');
+let path = require('path');
+let highlight = util.highlight;
 
-var emacs = require('./emacs');
+let emacs = require('./emacs');
 
-function get_content(elem){
-    elem('h1.title').remove();
-    var r = "";
-    var to_export = ['div#preamble', 'div#content', 'div#postamble'];
-    for(var i=0;i<to_export.length;i++){
-        var item = elem(to_export[i]);
-        // http://stackoverflow.com/questions/31044/is-there-an-exists-function-for-jquery
-        if(item.length){
-            r += item.html();
-        }
+function get_content(elem) {
+  elem('h1.title').remove();
+  let r = "";
+  let to_export = ['div#preamble', 'div#content', 'div#postamble'];
+  for (let i = 0; i < to_export.length; i++) {
+    let item = elem(to_export[i]);
+    // http://stackoverflow.com/questions/31044/is-there-an-exists-function-for-jquery
+    if (item.length) {
+      r += item.html();
     }
-    return r;
+  }
+  return r;
 }
 
 function render_html(html, config) {
-    return new Promise((reslove, reject) => {
+  return new Promise((reslove, reject) => {
 
-        // for use 'htmlize' to syntax highlight code block
-        if (config.org.htmlize)
-            reslove(html);
+    // for use 'htmlize' to syntax highlight code block
+    if (config.org.htmlize)
+      reslove(html);
 
-        // for use 'highlight.js' to syntax highlight code block (default)
-        config.highlight = config.highlight || {};
-        var $ = cheerio.load(html, {
-            ignoreWhitespace: false,
-            xmlMode: false,
-            lowerCaseTags: false,
-            decodeEntities: true
-        });
-
-
-        $('pre.src').each(function() {
-            var text; // await highlight code text
-            var lang = 'unknown';
-            var code = $(this);
-            var class_str = code.attr('class');
-            if (class_str.startsWith('src src-')) {
-                lang = class_str.substring('src src-'.length);
-            }
-            // In ox-hexml.el, I return the line-number with code text, we need to remove first-line to
-            // get line-number info
-
-            // remove first line
-            var lines = code.text().split('\n');
-
-            var firstLine = parseInt(lines[0]) + 1;
-
-            var gutter;// = config.org.line_number;
-            if (config.org.line_number)
-                gutter = true;
-            else {
-                gutter = (firstLine == 0) ? false : true;
-            }
-
-            // remove first line
-            lines.splice(0,1);
-            // remove newline
-            text = lines.join('\n').replace(/\n$/g,'');
-
-            // USE hexo.utils to render highlight.js code block
-            $(this).replaceWith( highlight(text, {
-                gutter: gutter,
-                autoDetect: config.highlight.auto_detect,
-                firstLine: firstLine,
-                lang: lang
-            }));
-        });
-
-        //reslove(get_content($));
-        reslove($.html());
+    // for use 'highlight.js' to syntax highlight code block (default)
+    config.highlight = config.highlight || {};
+    let $ = cheerio.load(html, {
+      ignoreWhitespace: false,
+      xmlMode: false,
+      lowerCaseTags: false,
+      decodeEntities: true
     });
+
+
+    $('pre.src').each(function() {
+      let text; // await highlight code text
+      let lang = 'unknown';
+      let code = $(this);
+      let class_str = code.attr('class');
+      if (class_str.startsWith('src src-')) {
+        lang = class_str.substring('src src-'.length);
+      }
+      // In ox-hexml.el, I return the line-number with code text, we need to remove first-line to
+      // get line-number info
+
+      // remove first line
+      let lines = code.text().split('\n');
+
+      let firstLine = parseInt(lines[0]) + 1;
+
+      let gutter; // = config.org.line_number;
+      if (config.org.line_number)
+        gutter = true;
+      else {
+        gutter = (firstLine == 0) ? false : true;
+      }
+
+      // remove first line
+      lines.splice(0, 1);
+      // remove newline
+      text = lines.join('\n').replace(/\n$/g, '');
+
+      // USE hexo.utils to render highlight.js code block
+      $(this).replaceWith(highlight(text, {
+        gutter: gutter,
+        autoDetect: config.highlight.auto_detect,
+        firstLine: firstLine,
+        lang: lang
+      }));
+    });
+
+    //reslove(get_content($));
+    reslove($.html());
+  });
+}
+
+function cache_and_convert(data, hexo) {
+  return new Promise((resolve, reject) => {
+    let config = hexo.config;
+    // wait for emacs server ready
+    hexo.log.info("render data.path", data.path);
+    // check cache
+    let cachefile = null;
+    if (config.org.cachedir) {
+      fs.mkdirsSync(config.org.cachedir);
+      cachefile = config.org.cachedir + md5(data.path);
+    }
+    let cache = null;
+    let content_md5 = null;
+    if (cachefile) {
+      if (!fs.existsSync(cachefile)) {
+        cache = {};
+      } else {
+        cache = jsonfile.readFileSync(cachefile);
+      }
+      let content = fs.readFileSync(data.path);
+
+      content_md5 = md5(content +
+        JSON.stringify(config.org) +
+        JSON.stringify(config.highlight));
+      if (cache.md5 == content_md5) { // hit cache
+        console.log(`${data.path} completed with cache`);
+        return resolve(cache.content);
+      }
+    }
+    return convert(data, hexo)
+      .then((html) => {
+        if (config.org.debug) console.log(html);
+        return render_html(html, config);
+      })
+      .then((result) => {
+        console.log(`${data.path} completed`);
+        if (cache !== null) {
+          cache.md5 = content_md5;
+          cache.content = result;
+          jsonfile.writeFileSync(cachefile, cache);
+        }
+        resolve(result);
+      });
+  });
 }
 
 function renderer(data) {
-    return emacs.server.wait(this).then(()=> {
-        return new Promise((resolve, reject) => {
-            var config = this.config;
-            // wait for emacs server ready
-            this.log.info("render data.path", data.path);
-            // check cache
-            var cachefile = null;
-            if(config.org.cachedir){
-                fs.mkdirsSync(config.org.cachedir);
-                cachefile = config.org.cachedir + md5(data.path);
-            }
-            var cache = null;
-            var content_md5 = null;
-            if(cachefile){
-                if(!fs.existsSync(cachefile)){
-                    cache = {};
-                }else{
-                    cache = jsonfile.readFileSync(cachefile);
-                }
-                var content = fs.readFileSync(data.path);
-
-                content_md5 = md5(content
-                                  + JSON.stringify(config.org)
-                                  + JSON.stringify(config.highlight));
-                if(cache.md5 == content_md5){ // hit cache
-                    console.log(`${data.path} completed with cache`);
-                    resolve(cache.content);
-                    return;
-                }
-            }
-            convert(data, this)
-                .then((html) => {
-                    return render_html(html, config);
-                })
-                .then((result) => {
-                    console.log(`${data.path} completed`);
-                    if(cache !== null){
-                        cache.md5 = content_md5;
-                        cache.content = result;
-                        jsonfile.writeFileSync(cachefile, cache);
-                    }
-                    resolve(result);
-                });
-        });
-
-    });
-
+  return cache_and_convert(data, this);
 }
 
 function convert(data, hexo) {
-    return new Promise((resolve, reject) => {
-        var config = hexo.config;
-        if (config.org.daemonize) {
-            emacs.client(hexo, data, resolve);
-        }
-        else {
-            emacs.process(hexo, data, resolve);
-        }
-    });
+  let config = hexo.config;
+  if (config.org.daemonize) {
+    return emacs.client(hexo, data);
+  } else {
+    return emacs.process(hexo, data);
+  }
 }
 
 module.exports = renderer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,474 @@
+{
+  "name": "hexo-renderer-org",
+  "version": "0.2.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "bufferhelper": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/bufferhelper/-/bufferhelper-0.2.1.tgz",
+      "integrity": "sha1-+nSjhXJKWOJC8ErWZGwjZvg7kT4="
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      }
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
+    "cheerio": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+      "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
+      "requires": {
+        "css-select": "~1.0.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "~3.8.1",
+        "lodash": "^3.2.0"
+      }
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
+    "css-select": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+      "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "1.0",
+        "domutils": "1.4",
+        "nth-check": "~1.0.0"
+      }
+    },
+    "css-what": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
+      "integrity": "sha1-18wt9FGAZm+Z0rFEYmOUaeAPc2w="
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "requires": {
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+      "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
+    },
+    "entities": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
+      }
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "hexo-util": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/hexo-util/-/hexo-util-0.1.7.tgz",
+      "integrity": "sha1-/chOG/IbGcTIaVQkWFqp8T7NY1M=",
+      "requires": {
+        "bluebird": "^2.6.2",
+        "ent": "^2.2.0",
+        "highlight.js": "^8.6.0"
+      }
+    },
+    "highlight.js": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-8.9.1.tgz",
+      "integrity": "sha1-uKnFSTISqTkvAiK2SclhFJfr+4g="
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "requires": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      },
+      "dependencies": {
+        "domutils": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "entities": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+          "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
+        }
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      }
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      }
+    },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "nth-check": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+      "requires": {
+        "os-tmpdir": "~1.0.1"
+      }
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var should = require('chai').should();
+let should = require('chai').should();
 
 describe('Org renderer', function() {
   this.timeout(100000);
   // in index.js
-  var assign = require('object-assign');
-  var ctx = {
+  let assign = require('object-assign');
+  let ctx = {
     config: {
       org: {
         emacs: 'emacs',
@@ -19,10 +19,10 @@ describe('Org renderer', function() {
     }
   };
 
-  var r = require('../lib/renderer').bind(ctx);
+  let r = require('../lib/renderer').bind(ctx);
   // org-html-postamble contains time and version info which is not easy to test
   it('rendering simple-test.org with org-html-postamble', function(){
-    var data = {
+    let data = {
       path: `${process.cwd()}/test/org/simple-test.org`,
       text: 'test' // did nothing
     };


### PR DESCRIPTION
Now, hexo-renderer-org won't start a new emacs server process in daemonize mode. It will use the activing one by connecting the exist emacs server socket file. You can use this codes to config the adress of emacs server socket file.

```yaml
     org:
       server_file: "~/.emacs.d/server/server"  # <----- this is default value
```

