### PR TITLE
Fix line numbering for 'shell' BEGIN_SRC block

### DIFF
--- a/emacs/ox-hexo.el
+++ b/emacs/ox-hexo.el
@@ -76,7 +76,7 @@ If you want to make example-block has line-number, you also need to setup `org-h
     ("ruby"            . "ruby")
     ("scss"            . "scss")
     ("sh"              . "bash")
-    ("shell"           . "shell")
+    ("shell"           . "bash")
     ("sql"             . "sql")
     ("stylus"          . "stylus")
     ("xml"             . "xml")


### PR DESCRIPTION
Only number '1' is displayed for the whole code block.