### PR TITLE
show server file path with md5

### DIFF
--- a/emacs/hexo-renderer-org.el
+++ b/emacs/hexo-renderer-org.el
@@ -30,6 +30,10 @@
 ;; when error, trigger an error buffer to make debug more easy
 (setq debug-on-error t)
 
+;; emacs 26.1 has a bug that it couldn't execute package-refresh-contents.
+;; set this variable to fix this bug.
+(setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3")
+
 ;; Ignore all directory-local variables in `.dir-locals.el', whick make Emacs stucks there.
 (setq enable-dir-local-variables nil)
 

--- a/lib/emacs.js
+++ b/lib/emacs.js
@@ -124,6 +124,7 @@ function emacs_server_start(hexo)
     var emacs_lisp = `
 (progn
   ;; Setup user's config
+  ${config.org.preloadScript === undefined? "": "(load " + config.org.preloadScript + ")"}
   (setq hexo-renderer-org-cachedir     "${fix_filepath(config.org.cachedir) || ""}")
   (setq hexo-renderer-org-user-config  "${fix_filepath(user_config) || ""}")
   (setq hexo-renderer-org-theme        "${config.org.theme || ""}")

--- a/lib/emacs.js
+++ b/lib/emacs.js
@@ -124,7 +124,7 @@ function emacs_server_start(hexo)
     var emacs_lisp = `
 (progn
   ;; Setup user's config
-  ${config.org.preloadScript === undefined? "": "(load " + config.org.preloadScript + ")"}
+  ${config.org.preloadScript === undefined? "": '(load "' + config.org.preloadScript + '")'}
   (setq hexo-renderer-org-cachedir     "${fix_filepath(config.org.cachedir) || ""}")
   (setq hexo-renderer-org-user-config  "${fix_filepath(user_config) || ""}")
   (setq hexo-renderer-org-theme        "${config.org.theme || ""}")

--- a/lib/emacs.js
+++ b/lib/emacs.js
@@ -6,6 +6,7 @@ var fs = require('fs-extra');
 var tmp = require('tmp');
 var path = require('path');
 var retry = require('retry');
+var md5 = require('md5');
 
 // A variable to save current config.org.emacsclient info
 var emacsclient = "emacsclient";
@@ -61,6 +62,11 @@ function update_server_file(hexo) {
     if (config.org.debug)
         console.log("Update server_file =", server_file);
     return server_file;
+}
+
+// The file path of hexo-renderer-org may be too long for emacs --daemon, short it with md5
+function get_server_name(hexo) {
+    return md5(get_server_file(hexo))
 }
 
 function get_server_file(hexo) {
@@ -140,7 +146,7 @@ function emacs_server_start(hexo)
     // Remove triling garbages
     emacs_lisp = fix_elisp(emacs_lisp);
 
-    var exec_args = ['-Q','--daemon=' + get_server_file(hexo), '--eval', emacs_lisp];
+    var exec_args = ['-Q','--daemon=' + get_server_name(hexo), '--eval', emacs_lisp];
 
     var proc = child_process.spawn(config.org.emacs, exec_args, {
         stdio: 'inherit'              // emacs's htmlize package need tty
@@ -172,7 +178,7 @@ function emacs_server_stop(hexo)
         if (!use_emacs_server)
             return;
 
-        var proc = child_process.spawn(emacsclient, ['-s', get_server_file(hexo), '-e', '(kill-emacs)'], {
+        var proc = child_process.spawn(emacsclient, ['-s', get_server_name(hexo), '-e', '(kill-emacs)'], {
             // detached: true
         });
 
@@ -207,7 +213,7 @@ function emacs_server_wait(hexo)
         if (!use_emacs_server)
             return;
 
-        var proc = child_process.spawn(emacsclient, ['-s', get_server_file(hexo), '-e', '(message "ping")'], {
+        var proc = child_process.spawn(emacsclient, ['-s', get_server_name(hexo), '-e', '(message "ping")'], {
         });
 
         proc.on('exit', function(code) {
@@ -262,7 +268,7 @@ function emacs_client(hexo, data, callback)
     // Remove triling garbages
     emacs_lisp = fix_elisp(emacs_lisp);
 
-    var exec_args = ['-s', get_server_file(hexo), '-e', emacs_lisp];
+    var exec_args = ['-s', get_server_name(hexo), '-e', emacs_lisp];
 
     // if (config.org.export_cfg != '')
     //    exec_args.splice(1,0,'--execute', config.org.export_cfg);

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ describe('Org renderer', function() {
     config: {
       org: {
         emacs: 'emacs',
+        preloadScript: undefined,
         export_cfg: '',
         common: '#+OPTIONS: html-postamble:nil',
         cachedir: './hexo-org-cache/',


### PR DESCRIPTION
原本用了hexo_renderer_org的文件路径作为emacs --daemon的名字，这个名字可能太长了，导致emacs server起不来。现在将这个文件路径改成用md5减短，解决这个问题。
#69 