### PR TITLE
修复文件过长导致emacs无法启动问题，并解决TOC乱码问题

### DIFF
--- a/lib/emacs.js
+++ b/lib/emacs.js
@@ -6,6 +6,7 @@ var fs = require('fs-extra');
 var tmp = require('tmp');
 var path = require('path');
 var retry = require('retry');
+var md5 = require('md5');
 
 // A variable to save current config.org.emacsclient info
 var emacsclient = "emacsclient";
@@ -61,6 +62,11 @@ function update_server_file(hexo) {
     if (config.org.debug)
         console.log("Update server_file =", server_file);
     return server_file;
+}
+
+// The file path of hexo-renderer-org may be too long for emacs --daemon, short it with md5
+function get_server_name(hexo) {
+    return md5(get_server_file(hexo))
 }
 
 function get_server_file(hexo) {
@@ -140,7 +146,7 @@ function emacs_server_start(hexo)
     // Remove triling garbages
     emacs_lisp = fix_elisp(emacs_lisp);
 
-    var exec_args = ['-Q','--daemon=' + get_server_file(hexo), '--eval', emacs_lisp];
+    var exec_args = ['-Q','--daemon=' + get_server_name(hexo), '--eval', emacs_lisp];
 
     var proc = child_process.spawn(config.org.emacs, exec_args, {
         stdio: 'inherit'              // emacs's htmlize package need tty
@@ -172,7 +178,7 @@ function emacs_server_stop(hexo)
         if (!use_emacs_server)
             return resolve();
 
-        var proc = child_process.spawn(emacsclient, ['-s', get_server_file(hexo), '-e', '(kill-emacs)'], {
+        var proc = child_process.spawn(emacsclient, ['-s', get_server_name(hexo), '-e', '(kill-emacs)'], {
             // detached: true
         });
 
@@ -207,7 +213,7 @@ function emacs_server_wait(hexo)
         if (!use_emacs_server)
             return resolve();
 
-        var proc = child_process.spawn(emacsclient, ['-s', get_server_file(hexo), '-e', '(message "ping")'], {
+        var proc = child_process.spawn(emacsclient, ['-s', get_server_name(hexo), '-e', '(message "ping")'], {
         });
 
         proc.on('exit', function(code) {
@@ -262,7 +268,7 @@ function emacs_client(hexo, data, callback)
     // Remove triling garbages
     emacs_lisp = fix_elisp(emacs_lisp);
 
-    var exec_args = ['-s', get_server_file(hexo), '-e', emacs_lisp];
+    var exec_args = ['-s', get_server_name(hexo), '-e', emacs_lisp];
 
     // if (config.org.export_cfg != '')
     //    exec_args.splice(1,0,'--execute', config.org.export_cfg);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -82,7 +82,7 @@ function render_html(html, config) {
         });
 
         //reslove(get_content($));
-        reslove($.html());
+        reslove($.html({decodeEntities: false}));
     });
 }
 


### PR DESCRIPTION
文件名过长导致emacs启动失败，这个方案使用的是@zhenghub 的方案，参考：
https://github.com/coldnew/hexo-renderer-org/pull/73

TOC乱码问题，参考：https://github.com/cheeriojs/cheerio/issues/866
